### PR TITLE
Use passlib for password hashing

### DIFF
--- a/E3-E4/fastapi/auth.py
+++ b/E3-E4/fastapi/auth.py
@@ -3,7 +3,7 @@ from typing import Optional
 from fastapi import Depends, HTTPException, status, Request
 from fastapi.security import HTTPBearer, HTTPAuthorizationCredentials
 from jose import JWTError, jwt
-import bcrypt
+from passlib.context import CryptContext
 from sqlalchemy.orm import Session
 from models import User, ClientUser
 from schemas import TokenData
@@ -16,13 +16,16 @@ ACCESS_TOKEN_EXPIRE_MINUTES = 30
 
 security = HTTPBearer(auto_error=False)
 
+# Contexte de hachage des mots de passe utilisant bcrypt via passlib
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
 def verify_password(plain_password, hashed_password):
-    """Vérifie un mot de passe avec bcrypt"""
-    return bcrypt.checkpw(plain_password.encode('utf-8'), hashed_password.encode('utf-8'))
+    """Vérifie un mot de passe à l'aide de passlib"""
+    return pwd_context.verify(plain_password, hashed_password)
 
 def get_password_hash(password):
-    """Hache un mot de passe avec bcrypt"""
-    return bcrypt.hashpw(password.encode('utf-8'), bcrypt.gensalt()).decode('utf-8')
+    """Hache un mot de passe à l'aide de passlib"""
+    return pwd_context.hash(password)
 
 def get_user(db: Session, username: str):
     return db.query(User).filter(User.username == username).first()

--- a/E3-E4/fastapi/requirements.txt
+++ b/E3-E4/fastapi/requirements.txt
@@ -9,6 +9,7 @@ sqlalchemy
 # Authentification et sécurité
 python-jose[cryptography]==3.3.0
 bcrypt==4.1.2
+passlib
 python-multipart==0.0.6
 
 # Templates et interface


### PR DESCRIPTION
## Summary
- add passlib to FastAPI requirements
- hash passwords using passlib's `CryptContext`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d5e53a5108326a2b1c0a3f477f952