### PR TITLE
Fix lint issues in routes.py

### DIFF
--- a/E3-E4/fastapi/routes.py
+++ b/E3-E4/fastapi/routes.py
@@ -6,10 +6,7 @@ from datetime import datetime, timedelta
 from typing import Optional, List
 import json
 import os
-from pathlib import Path
-
 from models import User, ClientUser, Conversation
-from schemas import UserCreate, UserLogin, Token, ChatMessage, ChatResponse, ConversationClose, ClientNameUpdate
 from auth import authenticate_user, create_access_token, get_current_active_user, get_client_user, is_client_only, is_staff_or_admin, get_password_hash
 from langchain_utils import initialize_faiss, load_all_jsons, get_conversation_history, save_uploaded_file
 


### PR DESCRIPTION
## Summary
- remove unused `Path` import and unused schema imports from `routes.py`

## Testing
- `flake8 E3-E4/fastapi/routes.py`
- `pytest -q` *(fails: Directory 'static' does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_688d700266ac832693502bb0ca4a3726