### PR TITLE
Add helper for OpenAI key retrieval

### DIFF
--- a/E3-E4/exemple/exemple.py
+++ b/E3-E4/exemple/exemple.py
@@ -229,6 +229,7 @@ class OpenaiView(LoginRequiredMixin, ExpeditionOnlyMixin, CentreUsinageOnlyMixin
             from .langchain_utils import initialize_faiss, load_all_jsons, get_conversation_history
             from langchain_openai import ChatOpenAI
             from langchain import hub
+            from utils import get_openai_api_key, MISSING_OPENAI_KEY_MSG
 
             data = json.loads(request.body.decode('utf-8'))
             user_input = data.get('message')
@@ -240,11 +241,10 @@ class OpenaiView(LoginRequiredMixin, ExpeditionOnlyMixin, CentreUsinageOnlyMixin
                 }, status=400)
             
             # Configuration de l'API key
-            openai_api_key = os.getenv('OPENAI_API_KEY')
-            if not openai_api_key:
-                return JsonResponse({
-                    "error": "Clé API OpenAI non configurée"
-                }, status=500)
+            try:
+                openai_api_key = get_openai_api_key()
+            except EnvironmentError:
+                return JsonResponse({"error": MISSING_OPENAI_KEY_MSG}, status=500)
             
             # Récupérer les données contextuelles en passant l'utilisateur connecté
             preprompt, client_json, renseignements, retours, commandes = load_all_jsons(user=request.user)
@@ -390,11 +390,11 @@ class OpenaiView(LoginRequiredMixin, ExpeditionOnlyMixin, CentreUsinageOnlyMixin
                     })
                 
                 # Configuration de l'API key
-                openai_api_key = os.getenv('OPENAI_API_KEY')
-                if not openai_api_key:
-                    return JsonResponse({
-                        "error": "Clé API OpenAI non configurée"
-                    }, status=500)
+                try:
+                    from utils import get_openai_api_key, MISSING_OPENAI_KEY_MSG
+                    openai_api_key = get_openai_api_key()
+                except EnvironmentError:
+                    return JsonResponse({"error": MISSING_OPENAI_KEY_MSG}, status=500)
                 
                 # Récupérer les informations client avec l'utilisateur connecté
                 preprompt, client_json, renseignements, retours, commandes = load_all_jsons(user=request.user)
@@ -452,11 +452,11 @@ class OpenaiView(LoginRequiredMixin, ExpeditionOnlyMixin, CentreUsinageOnlyMixin
                 conversation_id = request.POST.get('conversation_id')
                 
                 # Configuration de l'API key pour réutilisation
-                openai_api_key = os.getenv('OPENAI_API_KEY')
-                if not openai_api_key:
-                    return JsonResponse({
-                        "error": "Clé API OpenAI non configurée"
-                    }, status=500)
+                try:
+                    from utils import get_openai_api_key, MISSING_OPENAI_KEY_MSG
+                    openai_api_key = get_openai_api_key()
+                except EnvironmentError:
+                    return JsonResponse({"error": MISSING_OPENAI_KEY_MSG}, status=500)
                 
                 # Si c'est une conversation temporaire ou qu'il n'y a pas d'ID, créer une vraie conversation
                 if not conversation_id or conversation_id == "temp":

--- a/E3-E4/fastapi/routes.py
+++ b/E3-E4/fastapi/routes.py
@@ -12,6 +12,7 @@ from models import User, ClientUser, Conversation
 from schemas import UserCreate, UserLogin, Token, ChatMessage, ChatResponse, ConversationClose, ClientNameUpdate
 from auth import authenticate_user, create_access_token, get_current_active_user, get_client_user, is_client_only, is_staff_or_admin, get_password_hash
 from langchain_utils import initialize_faiss, load_all_jsons, get_conversation_history, save_uploaded_file
+from utils import get_openai_api_key, MISSING_OPENAI_KEY_MSG
 
 # Import de la fonction get_db depuis database
 from database import get_db
@@ -313,9 +314,10 @@ async def send_message(
             raise HTTPException(status_code=400, detail="Le message ne peut pas être vide")
         
         # Configuration OpenAI
-        openai_api_key = os.getenv('OPENAI_API_KEY')
-        if not openai_api_key:
-            raise HTTPException(status_code=500, detail="Clé API OpenAI non configurée")
+        try:
+            openai_api_key = get_openai_api_key()
+        except EnvironmentError:
+            raise HTTPException(status_code=500, detail=MISSING_OPENAI_KEY_MSG)
         
         # Récupérer les données contextuelles
         preprompt, client_json, renseignements, retours, commandes = load_all_jsons(user=current_user, db=db)
@@ -452,7 +454,10 @@ async def close_conversation(
             return {"status": "success", "message": "Conversation vide supprimée"}
         
         # Générer un résumé
-        openai_api_key = os.getenv('OPENAI_API_KEY')
+        try:
+            openai_api_key = get_openai_api_key()
+        except EnvironmentError:
+            openai_api_key = None
         if openai_api_key:
             from langchain_openai import ChatOpenAI
             llm = ChatOpenAI(api_key=openai_api_key, model="gpt-4o-mini", max_tokens=500, temperature=0.3)
@@ -485,9 +490,10 @@ async def upload_images(
             raise HTTPException(status_code=400, detail="Aucune image téléchargée")
         
         # Configuration OpenAI
-        openai_api_key = os.getenv('OPENAI_API_KEY')
-        if not openai_api_key:
-            raise HTTPException(status_code=500, detail="Clé API OpenAI non configurée")
+        try:
+            openai_api_key = get_openai_api_key()
+        except EnvironmentError:
+            raise HTTPException(status_code=500, detail=MISSING_OPENAI_KEY_MSG)
         
         # Récupérer ou créer conversation
         if conversation_id == "temp":

--- a/E3-E4/fastapi/tests/test_ai_integration.py
+++ b/E3-E4/fastapi/tests/test_ai_integration.py
@@ -7,7 +7,7 @@ from langchain_utils import (
     save_uploaded_file
 )
 from fastapi import UploadFile
-import os
+from utils import get_openai_api_key, MISSING_OPENAI_KEY_MSG
 from pathlib import Path
 
 class TestLangChainIntegration:
@@ -111,13 +111,12 @@ class TestAIIntegration:
     
     def test_openai_configuration(self):
         """Test de configuration OpenAI"""
-        # Vérifier que les variables d'environnement sont définies
-        api_key = os.getenv("OPENAI_API_KEY")
-        if api_key:
+        # Vérifier que les variables d'environnement sont définies via l'utilitaire
+        try:
+            api_key = get_openai_api_key()
             assert len(api_key) > 0
-        else:
-            # Si pas de clé API, c'est normal pour les tests
-            pass
+        except EnvironmentError as e:
+            assert str(e) == MISSING_OPENAI_KEY_MSG
     
     def test_faiss_index_existence(self):
         """Test de l'existence de l'index FAISS"""

--- a/E3-E4/fastapi/utils.py
+++ b/E3-E4/fastapi/utils.py
@@ -1,0 +1,14 @@
+import os
+
+MISSING_OPENAI_KEY_MSG = "OPENAI_API_KEY environment variable is missing"
+
+def get_openai_api_key() -> str:
+    """Return the OpenAI API key from the environment.
+
+    Raises:
+        EnvironmentError: if the OPENAI_API_KEY variable is not set.
+    """
+    api_key = os.getenv("OPENAI_API_KEY")
+    if not api_key:
+        raise EnvironmentError(MISSING_OPENAI_KEY_MSG)
+    return api_key


### PR DESCRIPTION
## Summary
- implement `get_openai_api_key` helper
- reuse helper in `routes.py`, Django example, and tests
- adjust integration test for new helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688d700b35a48326bfc2104e4bebec03