### PR TITLE
Remove duplicate page tests and pin httpx for FastAPI suite

### DIFF
--- a/E3-E4/fastapi/requirements.txt
+++ b/E3-E4/fastapi/requirements.txt
@@ -40,6 +40,7 @@ joblib
 
 # Requêtes HTTP
 requests
+httpx<0.28
 
 # Tests (pour le développement)
 pytest>=7.4.0
@@ -54,4 +55,4 @@ fuzzywuzzy
 alembic==1.12.1
 
 # CORS (pour les requêtes cross-origin)
-fastapi-cors==0.0.6 
+fastapi-cors==0.0.6

--- a/E3-E4/fastapi/tests/test_pages.py
+++ b/E3-E4/fastapi/tests/test_pages.py
@@ -1,8 +1,0 @@
-def test_login_page(client):
-    response = client.get("/login")
-    assert response.status_code == 200
-
-
-def test_register_page(client):
-    response = client.get("/register")
-    assert response.status_code == 200


### PR DESCRIPTION
## Summary
- remove redundant `test_pages.py`
- ensure login and register endpoints tested in `test_fastapi_endpoints.py`
- pin httpx<0.28 for test client compatibility

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e8e7eef548326a25899108f298ba4