### PR TITLE
chore: remove unused io import from fastapi tests

### DIFF
--- a/E3-E4/fastapi/tests/test_fastapi_endpoints.py
+++ b/E3-E4/fastapi/tests/test_fastapi_endpoints.py
@@ -1,6 +1,3 @@
-import io
-
-
 def test_login_page(client):
     response = client.get("/login")
     assert response.status_code == 200


### PR DESCRIPTION
## Summary
- remove unused io import from FastAPI endpoint tests

## Testing
- `pytest tests/test_fastapi_endpoints.py` *(fails: Client.__init__() got an unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_688e8e8004048326955501937fddea73