### PR TITLE
Add detailed content assertions to FastAPI tests

### DIFF
--- a/E3-E4/fastapi/tests/test_fastapi_endpoints.py
+++ b/E3-E4/fastapi/tests/test_fastapi_endpoints.py
@@ -4,16 +4,23 @@ import io
 def test_login_page(client):
     response = client.get("/login")
     assert response.status_code == 200
+    assert "Connexion" in response.text
 
 
 def test_register_page(client):
     response = client.get("/register")
     assert response.status_code == 200
+    assert "Inscription Client" in response.text
 
 
 def test_post_login(client):
-    response = client.post("/login", data={"username": "tester", "password": "password"}, allow_redirects=False)
+    response = client.post(
+        "/login",
+        data={"username": "tester", "password": "password"},
+        allow_redirects=False,
+    )
     assert response.status_code == 302
+    assert response.headers["location"] == "/conversations"
 
 
 def test_post_register(client):
@@ -23,41 +30,56 @@ def test_post_register(client):
         allow_redirects=False,
     )
     assert response.status_code == 302
+    assert response.headers["location"].startswith("/login")
+    assert "message=" in response.headers["location"]
 
 
 def test_logout(client):
     response = client.get("/logout", allow_redirects=False)
     assert response.status_code == 302
+    assert response.headers["location"] == "/login"
 
 
 def test_conversations_page(client):
     response = client.get("/conversations")
     assert response.status_code == 200
+    assert "Liste des conversations SAV" in response.text
 
 
 def test_conversation_detail(client, conversation):
     response = client.get(f"/conversation/{conversation.id}")
     assert response.status_code == 200
+    assert f"Conversation #{conversation.id}" in response.text
 
 
 def test_client_home_page(client):
-    response = client.get("/client_home")
-    assert response.status_code == 200
+    response = client.get("/client_home", allow_redirects=False)
+    assert response.status_code == 302
+    assert response.headers["location"] == "/conversations"
 
 
 def test_chat_page(client):
     response = client.get("/chat")
     assert response.status_code == 200
+    assert "chat-layout" in response.text
 
 
 def test_close_conversation_temp(client):
-    response = client.post("/api/close_conversation", data={"conversation_id": "temp"})
+    response = client.post(
+        "/api/close_conversation",
+        data={"conversation_id": "temp"},
+    )
     assert response.status_code == 200
+    assert response.json() == {
+        "status": "success",
+        "message": "Aucune conversation active \u00e0 cl\u00f4turer",
+    }
 
 
 def test_reset_chat(client):
     response = client.post("/api/reset_chat")
     assert response.status_code == 200
+    assert response.json() == {"status": "success", "conversation_id": "temp"}
 
 
 def test_update_client_name(client, conversation):
@@ -66,13 +88,21 @@ def test_update_client_name(client, conversation):
         data={"conversation_id": str(conversation.id), "client_name": "Updated"},
     )
     assert response.status_code == 200
+    assert response.json() == {
+        "status": "success",
+        "message": "Nom du client mis \u00e0 jour avec succ\u00e8s",
+    }
 
 
 def test_root_redirect(client):
     response = client.get("/", allow_redirects=False)
     assert response.status_code == 302
+    assert response.headers["location"] == "/login"
 
 
 def test_test_db_endpoint(client):
     response = client.get("/test-db")
     assert response.status_code == 200
+    data = response.json()
+    assert "status" in data
+    assert "message" in data

--- a/E3-E4/fastapi/tests/test_openai_api.py
+++ b/E3-E4/fastapi/tests/test_openai_api.py
@@ -21,6 +21,7 @@ def test_chat_endpoint_requires_key(client, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     response = client.post("/api/chat", data={"message": "hello", "conversation_id": "temp"})
     assert response.status_code == 500
+    assert "Erreur" in response.json()["detail"]
 
 
 def test_upload_images_requires_key(client, monkeypatch):
@@ -28,3 +29,4 @@ def test_upload_images_requires_key(client, monkeypatch):
     files = {"images": ("test.jpg", io.BytesIO(b"data"), "image/jpeg")}
     response = client.post("/api/upload_images", files=files, data={"conversation_id": "temp"})
     assert response.status_code == 500
+    assert "Erreur" in response.json()["detail"]


### PR DESCRIPTION
## Summary
- extend FastAPI endpoint tests to verify rendered content, redirect targets, and JSON payloads
- add error detail checks for OpenAI API endpoints when the API key is missing

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e8e812a80832689604482c6d5300b