### PR TITLE
Switch test client to httpx

### DIFF
--- a/E3-E4/fastapi/tests/conftest.py
+++ b/E3-E4/fastapi/tests/conftest.py
@@ -1,8 +1,9 @@
 import os
 from pathlib import Path
 import sys
+import asyncio
 import pytest
-from fastapi.testclient import TestClient
+from httpx import ASGITransport, AsyncClient
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from sqlalchemy.pool import StaticPool
@@ -67,7 +68,28 @@ def client(db, test_user):
     def override_current_active_user():
         return test_user
     app.dependency_overrides[get_current_active_user] = override_current_active_user
-    with TestClient(app) as c:
+    transport = ASGITransport(app=app)
+    client = AsyncClient(transport=transport, base_url="http://testserver")
+
+    class _SyncClient:
+        def __enter__(self_inner):
+            return self_inner
+
+        def __exit__(self_inner, exc_type, exc, tb):
+            asyncio.run(client.aclose())
+
+        def request(self_inner, method, url, **kwargs):
+            if "allow_redirects" in kwargs:
+                kwargs["follow_redirects"] = kwargs.pop("allow_redirects")
+            return asyncio.run(client.request(method, url, **kwargs))
+
+        def get(self_inner, url, **kwargs):
+            return self_inner.request("GET", url, **kwargs)
+
+        def post(self_inner, url, **kwargs):
+            return self_inner.request("POST", url, **kwargs)
+
+    with _SyncClient() as c:
         yield c
     app.dependency_overrides.pop(get_current_active_user, None)
 

--- a/E3-E4/fastapi/tests/test_fastapi_endpoints.py
+++ b/E3-E4/fastapi/tests/test_fastapi_endpoints.py
@@ -14,7 +14,7 @@ def test_post_login(client):
     response = client.post(
         "/login",
         data={"username": "tester", "password": "password"},
-        allow_redirects=False,
+        follow_redirects=False,
     )
     assert response.status_code == 302
     assert response.headers["location"] == "/conversations"
@@ -24,7 +24,7 @@ def test_post_register(client):
     response = client.post(
         "/register",
         data={"username": "newuser", "email": "new@ex.com", "password": "pass"},
-        allow_redirects=False,
+        follow_redirects=False,
     )
     assert response.status_code == 302
     assert response.headers["location"].startswith("/login")
@@ -32,7 +32,7 @@ def test_post_register(client):
 
 
 def test_logout(client):
-    response = client.get("/logout", allow_redirects=False)
+    response = client.get("/logout", follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["location"] == "/login"
 
@@ -50,7 +50,7 @@ def test_conversation_detail(client, conversation):
 
 
 def test_client_home_page(client):
-    response = client.get("/client_home", allow_redirects=False)
+    response = client.get("/client_home", follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["location"] == "/conversations"
 
@@ -92,7 +92,7 @@ def test_update_client_name(client, conversation):
 
 
 def test_root_redirect(client):
-    response = client.get("/", allow_redirects=False)
+    response = client.get("/", follow_redirects=False)
     assert response.status_code == 302
     assert response.headers["location"] == "/login"
 


### PR DESCRIPTION
## Summary
- replace deprecated FastAPI `TestClient` with httpx `AsyncClient` + `ASGITransport`
- update tests to use `follow_redirects` parameter

## Testing
- `cd E3-E4/fastapi && pytest`

------
https://chatgpt.com/codex/tasks/task_e_688ea82bbdac8326bad945808ff94957