### PR TITLE
Return 401 when OpenAI key missing

### DIFF
--- a/E3-E4/fastapi/routes.py
+++ b/E3-E4/fastapi/routes.py
@@ -361,7 +361,7 @@ async def send_message(
         try:
             openai_api_key = get_openai_api_key()
         except EnvironmentError:
-            raise HTTPException(status_code=500, detail=MISSING_OPENAI_KEY_MSG)
+            raise HTTPException(status_code=401, detail=MISSING_OPENAI_KEY_MSG)
         
         # Récupérer les données contextuelles
         preprompt, client_json, renseignements, retours, commandes = load_all_jsons(user=current_user, db=db)
@@ -440,6 +440,8 @@ async def send_message(
             "history": conversation.history
         }
         
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erreur: {str(e)}")
 
@@ -531,7 +533,7 @@ async def upload_images(
         try:
             openai_api_key = get_openai_api_key()
         except EnvironmentError:
-            raise HTTPException(status_code=500, detail=MISSING_OPENAI_KEY_MSG)
+            raise HTTPException(status_code=401, detail=MISSING_OPENAI_KEY_MSG)
         
         # Charger les informations client et récupérer ou créer la conversation
         preprompt, client_json, renseignements, retours, commandes = load_all_jsons(user=current_user)
@@ -593,6 +595,8 @@ async def upload_images(
             "history": conversation.history
         }
         
+    except HTTPException:
+        raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=f"Erreur: {str(e)}")
 

--- a/E3-E4/fastapi/tests/test_openai_api.py
+++ b/E3-E4/fastapi/tests/test_openai_api.py
@@ -20,13 +20,13 @@ def test_get_openai_api_key_missing(monkeypatch):
 def test_chat_endpoint_requires_key(client, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     response = client.post("/api/chat", data={"message": "hello", "conversation_id": "temp"})
-    assert response.status_code == 500
-    assert "Erreur" in response.json()["detail"]
+    assert response.status_code == 401
+    assert response.json()["detail"] == MISSING_OPENAI_KEY_MSG
 
 
 def test_upload_images_requires_key(client, monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     files = {"images": ("test.jpg", io.BytesIO(b"data"), "image/jpeg")}
     response = client.post("/api/upload_images", files=files, data={"conversation_id": "temp"})
-    assert response.status_code == 500
-    assert "Erreur" in response.json()["detail"]
+    assert response.status_code == 401
+    assert response.json()["detail"] == MISSING_OPENAI_KEY_MSG


### PR DESCRIPTION
## Summary
- Ensure `/api/chat` and `/api/upload_images` return 401 when `OPENAI_API_KEY` is missing
- Propagate HTTP exceptions instead of masking them as 500 errors
- Update tests to expect 401 and missing-key message

## Testing
- `python run_tests.py`

------
https://chatgpt.com/codex/tasks/task_e_688ea85ddc988326bc434cc7588aadb6