### PR TITLE
feat: track command info in conversations

### DIFF
--- a/E3-E4/fastapi/models.py
+++ b/E3-E4/fastapi/models.py
@@ -48,6 +48,8 @@ class Conversation(Base):
     status = Column(String, default="nouveau")  # nouveau, en_cours, termine
     history = Column(JSON, default=list)
     summary = Column(Text, nullable=True)
+    numero_commande = Column(String, nullable=True)
+    position_chassis = Column(String, nullable=True)
     user_id = Column(Integer, ForeignKey("users.id"), nullable=True)
     created_at = Column(DateTime, default=datetime.utcnow)
     updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)


### PR DESCRIPTION
## Summary
- store order number and chassis position on conversations
- parse customer messages to capture order info and strip step-1 instructions once both identifiers provided
- add regression test ensuring assistant doesn't re-ask for identifiers

## Testing
- `cd E3-E4/fastapi && pytest`


------
https://chatgpt.com/codex/tasks/task_e_688eebc2c5588326986162e65deb03a9