### PR TITLE
Set active conversation on creation

### DIFF
--- a/E3-E4/fastapi/routes.py
+++ b/E3-E4/fastapi/routes.py
@@ -63,6 +63,11 @@ def get_or_create_conversation(
         db.commit()
         db.refresh(conversation)
 
+        client_user = db.query(ClientUser).filter(ClientUser.user_id == user.id).first()
+        if client_user:
+            client_user.active_conversation_id = conversation.id
+            db.commit()
+
     return conversation
 
 # Route de connexion (GET)


### PR DESCRIPTION
## Summary
- update client user active conversation when creating a new conversation

## Testing
- `pytest` *(fails: test_post_login, test_client_home_page)*

------
https://chatgpt.com/codex/tasks/task_e_688f7a3940648326b7f9418d6093c956