### PR TITLE
feat: provide conversation object to chat template

### DIFF
--- a/E3-E4/fastapi/templates/openai_chat.html
+++ b/E3-E4/fastapi/templates/openai_chat.html
@@ -167,14 +167,12 @@
 {% endblock %} {% block content %}
 <div
     class="chat-layout"
-    {%
-    if
-    current_conversation
-    %}data-conversation-id="{{ current_conversation.id }}"
-    {%
-    endif
-    %}
-    data-conversation-status="{% if current_conversation %}{{ current_conversation.status }}{% else %}nouveau{% endif %}"
+    {% if current_conversation %}
+    data-conversation-id="{{ current_conversation.id }}"
+    data-conversation-status="{{ current_conversation.status }}"
+    {% else %}
+    data-conversation-status="nouveau"
+    {% endif %}
 >
     <div class="chat-container">
         <div class="chat-header">


### PR DESCRIPTION
## Summary
- return the fetched conversation object instead of id/history pair in chat page
- use `current_conversation` in chat template and expose conversation id/status via data attributes

## Testing
- `pytest` *(fails: test_post_login, test_client_home_page)*

------
https://chatgpt.com/codex/tasks/task_e_688f79fba9ec83268668698b8d9cd816